### PR TITLE
Add PreserveExec() to preserve lock across exec

### DIFF
--- a/fslock/flock_linux.go
+++ b/fslock/flock_linux.go
@@ -1,0 +1,54 @@
+// Copyright 2022 by Dan Jacques. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux || android
+
+package fslock
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// flock_lock is an implementation of lock using Linux flock().
+//
+// A process may only hold one type of lock (shared or exclusive) on a file.
+// Subsequent flock() calls on an already locked file will convert an existing
+// lock to the new lock mode. Attempts to acquire a file lock first check to
+// see if there is already a global entity holding the lock (fail), then attempt
+// to acquire the lock at a filesystem level.
+//
+// We can't use POSIX FcntlFlock because Linux has a bug in it's implementation
+// which different from the documented behaviour. If the process calling execve
+// is not the last thread of the process, the lock will be released even without
+// FD_CLOEXEC flag.
+// See also: crbug.com/1276120
+func flock_lock(l *L, fd *os.File) error {
+	// Use "flock()" to get a lock on the file.
+	//
+	// LOCK_EX: Exclusive lock
+	// LOCK_NB: Non-blocking.
+	flags := unix.LOCK_NB
+
+	if l.Shared {
+		flags |= unix.LOCK_SH
+	} else {
+		flags |= unix.LOCK_EX
+	}
+
+	if err := unix.Flock(int(fd.Fd()), flags); err != nil {
+		if errno, ok := err.(unix.Errno); ok {
+			switch errno {
+			case unix.EWOULDBLOCK:
+				// Someone else holds the lock on this file.
+				return ErrLockHeld
+			default:
+				return err
+			}
+		}
+		return err
+	}
+	return nil
+}

--- a/fslock/flock_linux.go
+++ b/fslock/flock_linux.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// flock_lock is an implementation of lock using Linux flock().
+// flockLock is an implementation of lock using Linux flock().
 //
 // A process may only hold one type of lock (shared or exclusive) on a file.
 // Subsequent flock() calls on an already locked file will convert an existing
@@ -25,7 +25,7 @@ import (
 // is not the last thread of the process, the lock will be released even without
 // FD_CLOEXEC flag.
 // See also: crbug.com/1276120
-func flock_lock(l *L, fd *os.File) error {
+func flockLock(l *L, fd *os.File) error {
 	// Use "flock()" to get a lock on the file.
 	//
 	// LOCK_EX: Exclusive lock

--- a/fslock/flock_linux.go
+++ b/fslock/flock_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2022 by Dan Jacques. All rights reserved.
+// Copyright 2022 by Chenlin Fan. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/fslock/flock_posix.go
+++ b/fslock/flock_posix.go
@@ -12,14 +12,14 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// flock_lock is an implementation of lock using POSIX locks via flock().
+// flockLock is an implementation of lock using POSIX locks via flock().
 //
 // flock() locks are released when *any* file handle to the locked file is
 // closed. To address this, we hold actual file handles globally. Attempts to
 // acquire a file lock first check to see if there is already a global entity
 // holding the lock (fail), then attempt to acquire the lock at a filesystem
 // level.
-func flock_lock(l *L, fd *os.File) error {
+func flockLock(l *L, fd *os.File) error {
 	// Use "flock()" to get a lock on the file.
 	//
 	lockcmd := unix.F_SETLK

--- a/fslock/flock_posix.go
+++ b/fslock/flock_posix.go
@@ -1,0 +1,47 @@
+// Copyright 2017 by Dan Jacques. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build darwin || freebsd || netbsd || openbsd || solaris || aix
+
+package fslock
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// flock_lock is an implementation of lock using POSIX locks via flock().
+//
+// flock() locks are released when *any* file handle to the locked file is
+// closed. To address this, we hold actual file handles globally. Attempts to
+// acquire a file lock first check to see if there is already a global entity
+// holding the lock (fail), then attempt to acquire the lock at a filesystem
+// level.
+func flock_lock(l *L, fd *os.File) error {
+	// Use "flock()" to get a lock on the file.
+	//
+	lockcmd := unix.F_SETLK
+	lockstr := unix.Flock_t{
+		Type: unix.F_WRLCK, Start: 0, Len: 0, Whence: 1,
+	}
+
+	if l.Shared {
+		lockstr.Type = unix.F_RDLCK
+	}
+
+	if err := unix.FcntlFlock(fd.Fd(), lockcmd, &lockstr); err != nil {
+		if errno, ok := err.(unix.Errno); ok {
+			switch errno {
+			case unix.EWOULDBLOCK:
+				// Someone else holds the lock on this file.
+				return ErrLockHeld
+			default:
+				return err
+			}
+		}
+		return err
+	}
+	return nil
+}

--- a/fslock/lock.go
+++ b/fslock/lock.go
@@ -36,12 +36,13 @@ type Handle interface {
 	// unspecified.
 	LockFile() *os.File
 
-	// PreserveExec preserve the lock across execve syscall.
+	// PreserveExec preserves the lock across execve syscall.
 	//
 	// The lock will be held even after call execve. It is not possible to
-	// acquire a handle for the lock unless manually pass the fd as an argument.
+	// acquire a handle for the lock unless manually passing the fd as an
+	// argument.
 	//
-	// On windows, the behaviour is not promised unless CreateProcess with
+	// On Windows, the behaviour is not promised unless CreateProcess with
 	// bInheritHandles.
 	PreserveExec() error
 }

--- a/fslock/lock.go
+++ b/fslock/lock.go
@@ -35,6 +35,15 @@ type Handle interface {
 	// closed with Unlock, the file's state is implementation-specific and
 	// unspecified.
 	LockFile() *os.File
+
+	// PreserveExec preserve the lock across execve syscall.
+	//
+	// The lock will be held even after call execve. It is not possible to
+	// acquire a handle for the lock unless manually pass the fd as an argument.
+	//
+	// On windows, the behaviour is not promised unless CreateProcess with
+	// bInheritHandles.
+	PreserveExec() error
 }
 
 // Blocker is used for the Delay field in a Lock.


### PR DESCRIPTION
Add PreserveExec() to preserve lock across exec.

To preserve lock across exec, we can't use FcntlFlock due to a Linux kernel bug. If the process calling execve is not the last thread of the process, the lock will be released even without FD_CLOEXEC flag.

Also use platform dependent unix and windows packages instead of deprecated syscall package:

> Deprecated: this package is locked down. Callers should use the corresponding package in the golang.org/x/sys repository instead. That is also where updates required by new systems or versions should be applied. See https://golang.org/s/go1.4-syscall for more information.

See also: crbug.com/1276120