### PR TITLE
Add legacy build tags for go compilers before 1.17

### DIFF
--- a/fslock/flock_linux.go
+++ b/fslock/flock_linux.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux || android
+// +build linux android
 
 package fslock
 

--- a/fslock/flock_posix.go
+++ b/fslock/flock_posix.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin || freebsd || netbsd || openbsd || solaris || aix
+// +build darwin freebsd netbsd openbsd solaris aix
 
 package fslock
 

--- a/fslock/lock_unix.go
+++ b/fslock/lock_unix.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 //go:build !windows
+// +build !windows
 
 package fslock
 


### PR DESCRIPTION
Didn't realize that //go:build only works for go >= 1.17. We should keep the legacy build tags for compatibility.