### PR TITLE
Add dragonfly compatibility, future-proof

### DIFF
--- a/fslock/flock_posix.go
+++ b/fslock/flock_posix.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build darwin || freebsd || netbsd || openbsd || solaris || aix
-// +build darwin freebsd netbsd openbsd solaris aix
+//go:build darwin || freebsd || netbsd || openbsd || solaris || aix || dragonfly || (unix && !linux && !android)
+// +build darwin freebsd netbsd openbsd solaris aix dragonfly unix,!linux,!android
 
 package fslock
 


### PR DESCRIPTION
The build tags on flock_posix.go didn't treat dragonfly as a Unix. Add it, and also start using the unix build tag added in 1.19 to be more future-proof.