### PR TITLE
fix go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/danjacques/gofslock
 
-go 1.0
+go 1.14
 
 require golang.org/x/sys v0.1.0


### PR DESCRIPTION
Go 1.22 breaks modules that declare go 1.0: https://github.com/golang/go/issues/65528

This PR modifies the Go version in go.mod to 1.14 because module must run on Go version 1.14 or later, as documented in https://go.dev/doc/modules/gomod-ref